### PR TITLE
add closing ``` to the last code panel

### DIFF
--- a/_cheatsheets/docker-cheatsheet.md
+++ b/_cheatsheets/docker-cheatsheet.md
@@ -1461,3 +1461,4 @@ docker run --tmpfs /app/tmp:rw,size=100m,mode=1777 nginx
 
 # Device mapping
 docker run --device /dev/sda:/dev/xvda:rwm ubuntu
+```


### PR DESCRIPTION
without it, the web page layout at the bottom of this page:

https://scthornton.github.io/cheatsheets/docker-cheatsheet/

is broken